### PR TITLE
Adds a "build" action to build on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: build
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots verify

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![](https://github.com/paulhoadley/vermilingua-maven-plugin/workflows/build/badge.svg)
 <img align="right" src="https://www.hugi.io/github/img/antkiller2.png" width="60">
 
 ## What is This? A Center for Ants? 


### PR DESCRIPTION
This is a bare minimum build action to kick off some continuous integration. Note that the _badge_ in `README.md` points at this fork, so if you merge this PR you'd presumably want to immediately update that. (How _is_ this supposed to work between forks? We'd have warring commits to `README.md`, each trying to update that badge, wouldn't we?)